### PR TITLE
feat: Add Full Schema Migration for Constraints, Triggers, and Views

### DIFF
--- a/DbRosetta.Core/DIALETS/SqlServerDialect.cs
+++ b/DbRosetta.Core/DIALETS/SqlServerDialect.cs
@@ -39,7 +39,10 @@ public class SqlServerTypeMapper : IDatabaseTypeMapper
         { "uniqueidentifier", DbType.Guid },
         { "varbinary", DbType.Binary },
         { "varchar", DbType.AnsiString },
-        { "xml", DbType.Xml }
+        { "xml", DbType.Xml },
+        { "hierarchyid", DbType.String },
+        { "geography", DbType.String },
+        { "geometry", DbType.String }
     };
 
     public DbType MapToGenericType(string dbTypeName)

--- a/DbRosetta.Core/DbRosetta.Core.csproj
+++ b/DbRosetta.Core/DbRosetta.Core.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="WRITERS\" />
-    <Folder Include="READERS\" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.9" />
   </ItemGroup>
 
 </Project>

--- a/DbRosetta.Core/INTERFACES/IDataMigrator.cs
+++ b/DbRosetta.Core/INTERFACES/IDataMigrator.cs
@@ -1,0 +1,20 @@
+﻿using System.Data.Common;
+
+/// <summary>
+/// Defines the contract for migrating data from a source to a destination database.
+/// </summary>
+public interface IDataMigrator
+{
+    /// <summary>
+    /// Migrates data for a given list of tables.
+    /// </summary>
+    /// <param name="sourceConnection">An open connection to the source database.</param>
+    /// <param name="destinationConnection">An open connection to the destination database.</param>
+    /// <param name="tables">The schema of the tables whose data needs to be migrated.</param>
+    /// <param name="progressAction">An action to report progress on rows migrated per table.</param>
+    Task MigrateDataAsync(
+        DbConnection sourceConnection,
+        DbConnection destinationConnection,
+        List<TableSchema> tables,
+        Action<string, long> progressAction);
+}

--- a/DbRosetta.Core/INTERFACES/IDatabaseSchemaReader.cs
+++ b/DbRosetta.Core/INTERFACES/IDatabaseSchemaReader.cs
@@ -3,4 +3,11 @@
 public interface IDatabaseSchemaReader
 {
     Task<List<TableSchema>> GetTablesAsync(DbConnection connection);
+
+    /// <summary>
+    /// Reads only the view definitions from the database.
+    /// </summary>
+    /// <param name="connection">An open connection to the source database.</param>
+    /// <returns>A list of ViewSchema objects.</returns>
+    Task<List<ViewSchema>> GetViewsAsync(DbConnection connection);
 }

--- a/DbRosetta.Core/INTERFACES/IDatabaseSchemaReader.cs
+++ b/DbRosetta.Core/INTERFACES/IDatabaseSchemaReader.cs
@@ -1,0 +1,6 @@
+﻿using System.Data.Common;
+
+public interface IDatabaseSchemaReader
+{
+    Task<List<TableSchema>> GetTablesAsync(DbConnection connection);
+}

--- a/DbRosetta.Core/INTERFACES/IDatabaseWriter.cs
+++ b/DbRosetta.Core/INTERFACES/IDatabaseWriter.cs
@@ -1,0 +1,16 @@
+﻿using System.Data.Common;
+
+/// <summary>
+/// Defines the contract for writing a database schema to a target database.
+/// </summary>
+public interface IDatabaseWriter
+{
+    /// <summary>
+    /// Generates and executes the necessary SQL to create the database schema.
+    /// </summary>
+    /// <param name="connection">An open connection to the target database.</param>
+    /// <param name="tables">The list of table schemas to create.</param>
+    /// <param name="typeService">The service used for translating data types.</param>
+    /// <param name="sourceDialectName">The name of the original source dialect.</param>
+    Task WriteSchemaAsync(DbConnection connection, List<TableSchema> tables, TypeMappingService typeService, string sourceDialectName);
+}

--- a/DbRosetta.Core/INTERFACES/IDatabaseWriter.cs
+++ b/DbRosetta.Core/INTERFACES/IDatabaseWriter.cs
@@ -1,16 +1,16 @@
 ﻿using System.Data.Common;
 
-/// <summary>
-/// Defines the contract for writing a database schema to a target database.
-/// </summary>
 public interface IDatabaseWriter
 {
     /// <summary>
-    /// Generates and executes the necessary SQL to create the database schema.
+    /// Generates and executes the necessary SQL to create the database tables and related objects.
+    /// </summary>
+    Task WriteSchemaAsync(DbConnection connection, List<TableSchema> tables, TypeMappingService typeService, string sourceDialectName);
+
+    /// <summary>
+    /// Generates and executes the necessary SQL to create the database views.
     /// </summary>
     /// <param name="connection">An open connection to the target database.</param>
-    /// <param name="tables">The list of table schemas to create.</param>
-    /// <param name="typeService">The service used for translating data types.</param>
-    /// <param name="sourceDialectName">The name of the original source dialect.</param>
-    Task WriteSchemaAsync(DbConnection connection, List<TableSchema> tables, TypeMappingService typeService, string sourceDialectName);
+    /// <param name="views">The list of view schemas to create.</param>
+    Task WriteViewsAsync(DbConnection connection, List<ViewSchema> views);
 }

--- a/DbRosetta.Core/MODELS/ColumnSchema.cs
+++ b/DbRosetta.Core/MODELS/ColumnSchema.cs
@@ -1,0 +1,12 @@
+﻿public class ColumnSchema
+{
+    public string ColumnName { get; set; } = string.Empty;
+    public string ColumnType { get; set; } = string.Empty; // The original, source-specific data type
+    public int Length { get; set; }
+    public int Precision { get; set; }
+    public int Scale { get; set; }
+    public bool IsNullable { get; set; }
+    public string DefaultValue { get; set; } = string.Empty;
+    public bool IsIdentity { get; set; }
+    public bool? IsCaseSensitivite { get; set; }
+}

--- a/DbRosetta.Core/MODELS/DatabaseSchema.cs
+++ b/DbRosetta.Core/MODELS/DatabaseSchema.cs
@@ -1,0 +1,5 @@
+﻿public class DatabaseSchema
+{
+    public List<TableSchema> Tables { get; set; } = new();
+    public List<ViewSchema> Views { get; set; } = new();
+}

--- a/DbRosetta.Core/MODELS/ForeignKeySchema.cs
+++ b/DbRosetta.Core/MODELS/ForeignKeySchema.cs
@@ -1,0 +1,32 @@
+﻿public class ForeignKeySchema
+{
+    /// <summary>
+    /// The name of the table that contains the foreign key.
+    /// </summary>
+    public string TableName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The name of the column that is the foreign key.
+    /// </summary>
+    public string ColumnName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The name of the table that the foreign key references.
+    /// </summary>
+    public string ForeignTableName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The name of the column in the foreign table that is being referenced.
+    /// </summary>
+    public string ForeignColumnName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Indicates if the constraint uses CASCADE on delete.
+    /// </summary>
+    public bool CascadeOnDelete { get; set; }
+
+    /// <summary>
+    /// Indicates if the foreign key column is nullable.
+    /// </summary>
+    public bool IsNullable { get; set; }
+}

--- a/DbRosetta.Core/MODELS/IndexSchema.cs
+++ b/DbRosetta.Core/MODELS/IndexSchema.cs
@@ -1,0 +1,12 @@
+﻿public class IndexSchema
+{
+    public string IndexName { get; set; } = string.Empty;
+    public bool IsUnique { get; set; }
+    public List<IndexColumn> Columns { get; set; } = new();
+}
+
+public class IndexColumn
+{
+    public string ColumnName { get; set; } = string.Empty;
+    public bool IsAscending { get; set; }
+}

--- a/DbRosetta.Core/MODELS/TableSchema.cs
+++ b/DbRosetta.Core/MODELS/TableSchema.cs
@@ -7,4 +7,14 @@
     public List<ForeignKeySchema> ForeignKeys { get; set; } = new();
     public List<IndexSchema> Indexes { get; set; } = new();
     public List<string> CheckConstraints { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the list of UNIQUE constraints for this table.
+    /// </summary>
+    public List<UniqueConstraintSchema> UniqueConstraints { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the list of Triggers associated with this table.
+    /// </summary>
+    public List<TriggerSchema> Triggers { get; set; } = new();
 }

--- a/DbRosetta.Core/MODELS/TableSchema.cs
+++ b/DbRosetta.Core/MODELS/TableSchema.cs
@@ -1,0 +1,9 @@
+﻿public class TableSchema
+{
+    public string TableName { get; set; } = string.Empty;
+    public string TableSchemaName { get; set; } = string.Empty; // e.g., "dbo" in SQL Server
+    public List<ColumnSchema> Columns { get; set; } = new();
+    public List<string> PrimaryKey { get; set; } = new();
+    public List<ForeignKeySchema> ForeignKeys { get; set; } = new();
+    public List<IndexSchema> Indexes { get; set; } = new();
+}

--- a/DbRosetta.Core/MODELS/TableSchema.cs
+++ b/DbRosetta.Core/MODELS/TableSchema.cs
@@ -6,4 +6,5 @@
     public List<string> PrimaryKey { get; set; } = new();
     public List<ForeignKeySchema> ForeignKeys { get; set; } = new();
     public List<IndexSchema> Indexes { get; set; } = new();
+    public List<string> CheckConstraints { get; set; } = new();
 }

--- a/DbRosetta.Core/MODELS/TriggerSchema.cs
+++ b/DbRosetta.Core/MODELS/TriggerSchema.cs
@@ -1,0 +1,21 @@
+﻿public enum TriggerEvent
+{
+    Delete,
+    Update,
+    Insert
+}
+
+public enum TriggerType
+{
+    After,
+    Before
+}
+
+public class TriggerSchema
+{
+    public string Name { get; set; } = string.Empty;
+    public TriggerEvent Event { get; set; }
+    public TriggerType Type { get; set; }
+    public string Body { get; set; } = string.Empty;
+    public string Table { get; set; } = string.Empty;
+}

--- a/DbRosetta.Core/MODELS/TriggerSchema.cs
+++ b/DbRosetta.Core/MODELS/TriggerSchema.cs
@@ -1,4 +1,5 @@
-﻿public enum TriggerEvent
+﻿
+public enum TriggerEvent
 {
     Delete,
     Update,
@@ -8,7 +9,11 @@
 public enum TriggerType
 {
     After,
-    Before
+    Before,
+    /// <summary>
+    /// Represents an INSTEAD OF trigger, common in SQL Server.
+    /// </summary>
+    InsteadOf // This was the missing definition
 }
 
 public class TriggerSchema

--- a/DbRosetta.Core/MODELS/UniqueConstraintSchema.cs
+++ b/DbRosetta.Core/MODELS/UniqueConstraintSchema.cs
@@ -1,0 +1,9 @@
+﻿
+/// <summary>
+/// Represents a UNIQUE constraint from the source database.
+/// </summary>
+public class UniqueConstraintSchema
+{
+    public string ConstraintName { get; set; } = string.Empty;
+    public List<string> Columns { get; set; } = new();
+}

--- a/DbRosetta.Core/MODELS/ViewSchema.cs
+++ b/DbRosetta.Core/MODELS/ViewSchema.cs
@@ -1,0 +1,5 @@
+﻿public class ViewSchema
+{
+    public string ViewName { get; set; } = string.Empty;
+    public string ViewSQL { get; set; } = string.Empty;
+}

--- a/DbRosetta.Core/READERS/SqlServerSchemaReader.cs
+++ b/DbRosetta.Core/READERS/SqlServerSchemaReader.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.Data.SqlClient;
+using System.Data.Common;
+
+public class SqlServerSchemaReader : IDatabaseSchemaReader
+    {
+        public async Task<List<TableSchema>> GetTablesAsync(DbConnection connection)
+        {
+            if (!(connection is SqlConnection sqlConnection))
+            {
+                throw new ArgumentException("A SqlConnection is required.", nameof(connection));
+            }
+
+            var tables = new List<TableSchema>();
+            var command = new SqlCommand("SELECT TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE'", sqlConnection);
+
+            using (var reader = await command.ExecuteReaderAsync())
+            {
+                while (await reader.ReadAsync())
+                {
+                    var tableSchema = new TableSchema
+                    {
+                        TableSchemaName = reader.GetString(0),
+                        TableName = reader.GetString(1)
+                    };
+                    tables.Add(tableSchema);
+                }
+            }
+
+            // Now, for each table, get its detailed schema
+            foreach (var table in tables)
+            {
+                table.Columns = await GetColumnsForTableAsync(sqlConnection, table.TableName);
+                table.PrimaryKey = await GetPrimaryKeyForTableAsync(sqlConnection, table.TableName);
+                // Future work: Get Foreign Keys and Indexes
+            }
+
+            return tables;
+        }
+
+        private async Task<List<ColumnSchema>> GetColumnsForTableAsync(SqlConnection connection, string tableName)
+        {
+            // Same as before
+            var columns = new List<ColumnSchema>();
+            var command = new SqlCommand(@"
+                SELECT 
+                    COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH,
+                    IS_NULLABLE, COLUMN_DEFAULT, NUMERIC_PRECISION, NUMERIC_SCALE
+                FROM INFORMATION_SCHEMA.COLUMNS 
+                WHERE TABLE_NAME = @TableName
+                ORDER BY ORDINAL_POSITION", connection);
+            command.Parameters.AddWithValue("@TableName", tableName);
+            using (var reader = await command.ExecuteReaderAsync())
+            {
+                while (await reader.ReadAsync())
+                {
+                    columns.Add(new ColumnSchema
+                    {
+                        ColumnName = reader["COLUMN_NAME"].ToString()!,
+                        ColumnType = reader["DATA_TYPE"].ToString()!,
+                        Length = reader["CHARACTER_MAXIMUM_LENGTH"] != DBNull.Value ? Convert.ToInt32(reader["CHARACTER_MAXIMUM_LENGTH"]) : 0,
+                        IsNullable = reader["IS_NULLABLE"].ToString()!.Equals("YES", StringComparison.OrdinalIgnoreCase),
+                        DefaultValue = reader["COLUMN_DEFAULT"]?.ToString() ?? string.Empty,
+                        Precision = reader["NUMERIC_PRECISION"] != DBNull.Value ? Convert.ToInt32(reader["NUMERIC_PRECISION"]) : 0,
+                        Scale = reader["NUMERIC_SCALE"] != DBNull.Value ? Convert.ToInt32(reader["NUMERIC_SCALE"]) : 0
+                    });
+                }
+            }
+            return columns;
+        }
+
+        private async Task<List<string>> GetPrimaryKeyForTableAsync(SqlConnection connection, string tableName)
+        {
+            var primaryKeys = new List<string>();
+            // sp_pkeys is a legacy but simple way to get PKs
+            var command = new SqlCommand($"EXEC sp_pkeys '{tableName}'", connection);
+            using (var reader = await command.ExecuteReaderAsync())
+            {
+                while (await reader.ReadAsync())
+                {
+                    primaryKeys.Add(reader["COLUMN_NAME"].ToString()!);
+                }
+            }
+            return primaryKeys;
+        }
+    }

--- a/DbRosetta.Core/READERS/SqlServerSchemaReader.cs
+++ b/DbRosetta.Core/READERS/SqlServerSchemaReader.cs
@@ -1,85 +1,188 @@
-﻿using Microsoft.Data.SqlClient;
-using System.Data.Common;
+﻿using System.Data.Common;
+using Microsoft.Data.SqlClient;
 
 public class SqlServerSchemaReader : IDatabaseSchemaReader
+{
+    private async Task<List<ColumnSchema>> GetColumnsForTableAsync(SqlConnection connection, string tableName)
     {
-        public async Task<List<TableSchema>> GetTablesAsync(DbConnection connection)
-        {
-            if (!(connection is SqlConnection sqlConnection))
-            {
-                throw new ArgumentException("A SqlConnection is required.", nameof(connection));
-            }
-
-            var tables = new List<TableSchema>();
-            var command = new SqlCommand("SELECT TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE'", sqlConnection);
-
-            using (var reader = await command.ExecuteReaderAsync())
-            {
-                while (await reader.ReadAsync())
-                {
-                    var tableSchema = new TableSchema
-                    {
-                        TableSchemaName = reader.GetString(0),
-                        TableName = reader.GetString(1)
-                    };
-                    tables.Add(tableSchema);
-                }
-            }
-
-            // Now, for each table, get its detailed schema
-            foreach (var table in tables)
-            {
-                table.Columns = await GetColumnsForTableAsync(sqlConnection, table.TableName);
-                table.PrimaryKey = await GetPrimaryKeyForTableAsync(sqlConnection, table.TableName);
-                // Future work: Get Foreign Keys and Indexes
-            }
-
-            return tables;
-        }
-
-        private async Task<List<ColumnSchema>> GetColumnsForTableAsync(SqlConnection connection, string tableName)
-        {
-            // Same as before
-            var columns = new List<ColumnSchema>();
-            var command = new SqlCommand(@"
+        // Same as before
+        var columns = new List<ColumnSchema>();
+        var command = new SqlCommand(@"
                 SELECT 
                     COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH,
                     IS_NULLABLE, COLUMN_DEFAULT, NUMERIC_PRECISION, NUMERIC_SCALE
                 FROM INFORMATION_SCHEMA.COLUMNS 
                 WHERE TABLE_NAME = @TableName
                 ORDER BY ORDINAL_POSITION", connection);
-            command.Parameters.AddWithValue("@TableName", tableName);
-            using (var reader = await command.ExecuteReaderAsync())
+        command.Parameters.AddWithValue("@TableName", tableName);
+        using (var reader = await command.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
             {
-                while (await reader.ReadAsync())
+                columns.Add(new ColumnSchema
                 {
-                    columns.Add(new ColumnSchema
-                    {
-                        ColumnName = reader["COLUMN_NAME"].ToString()!,
-                        ColumnType = reader["DATA_TYPE"].ToString()!,
-                        Length = reader["CHARACTER_MAXIMUM_LENGTH"] != DBNull.Value ? Convert.ToInt32(reader["CHARACTER_MAXIMUM_LENGTH"]) : 0,
-                        IsNullable = reader["IS_NULLABLE"].ToString()!.Equals("YES", StringComparison.OrdinalIgnoreCase),
-                        DefaultValue = reader["COLUMN_DEFAULT"]?.ToString() ?? string.Empty,
-                        Precision = reader["NUMERIC_PRECISION"] != DBNull.Value ? Convert.ToInt32(reader["NUMERIC_PRECISION"]) : 0,
-                        Scale = reader["NUMERIC_SCALE"] != DBNull.Value ? Convert.ToInt32(reader["NUMERIC_SCALE"]) : 0
-                    });
-                }
+                    ColumnName = reader["COLUMN_NAME"].ToString()!,
+                    ColumnType = reader["DATA_TYPE"].ToString()!,
+                    Length = reader["CHARACTER_MAXIMUM_LENGTH"] != DBNull.Value ? Convert.ToInt32(reader["CHARACTER_MAXIMUM_LENGTH"]) : 0,
+                    IsNullable = reader["IS_NULLABLE"].ToString()!.Equals("YES", StringComparison.OrdinalIgnoreCase),
+                    DefaultValue = reader["COLUMN_DEFAULT"]?.ToString() ?? string.Empty,
+                    Precision = reader["NUMERIC_PRECISION"] != DBNull.Value ? Convert.ToInt32(reader["NUMERIC_PRECISION"]) : 0,
+                    Scale = reader["NUMERIC_SCALE"] != DBNull.Value ? Convert.ToInt32(reader["NUMERIC_SCALE"]) : 0
+                });
             }
-            return columns;
+        }
+        return columns;
+    }
+
+    private async Task<List<string>> GetPrimaryKeyForTableAsync(SqlConnection connection, string tableName)
+    {
+        var primaryKeys = new List<string>();
+        // sp_pkeys is a legacy but simple way to get PKs
+        var command = new SqlCommand($"EXEC sp_pkeys '{tableName}'", connection);
+        using (var reader = await command.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+            {
+                primaryKeys.Add(reader["COLUMN_NAME"].ToString()!);
+            }
+        }
+        return primaryKeys;
+    }
+
+
+public async Task<List<TableSchema>> GetTablesAsync(DbConnection connection)
+    {
+        if (!(connection is SqlConnection sqlConnection))
+        {
+            throw new ArgumentException("A SqlConnection is required.", nameof(connection));
         }
 
-        private async Task<List<string>> GetPrimaryKeyForTableAsync(SqlConnection connection, string tableName)
+        var tables = new List<TableSchema>();
+        var command = new SqlCommand("SELECT TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE'", sqlConnection);
+
+        using (var reader = await command.ExecuteReaderAsync())
         {
-            var primaryKeys = new List<string>();
-            // sp_pkeys is a legacy but simple way to get PKs
-            var command = new SqlCommand($"EXEC sp_pkeys '{tableName}'", connection);
+            while (await reader.ReadAsync())
+            {
+                tables.Add(new TableSchema
+                {
+                    TableSchemaName = reader.GetString(0),
+                    TableName = reader.GetString(1)
+                });
+            }
+        }
+
+        // Now, for each table, get its detailed schema
+        foreach (var table in tables)
+        {
+            table.Columns = await GetColumnsForTableAsync(sqlConnection, table.TableName);
+            table.PrimaryKey = await GetPrimaryKeyForTableAsync(sqlConnection, table.TableName);
+
+            // --- NEW: Read Foreign Keys and Indexes ---
+            table.ForeignKeys = await GetForeignKeysForTableAsync(sqlConnection, table.TableName, table.TableSchemaName);
+            table.Indexes = await GetIndexesForTableAsync(sqlConnection, table.TableName, table.TableSchemaName);
+        }
+
+        return tables;
+    }
+
+    // ... GetColumnsForTableAsync and GetPrimaryKeyForTableAsync methods remain the same ...
+
+    // --- NEW METHOD: Get Foreign Keys ---
+    private async Task<List<ForeignKeySchema>> GetForeignKeysForTableAsync(SqlConnection connection, string tableName, string tableSchema)
+    {
+        var foreignKeys = new List<ForeignKeySchema>();
+        var command = new SqlCommand(@"
+                SELECT 
+                    fk.TABLE_NAME AS FkTable,
+                    kcu.COLUMN_NAME AS FkColumn,
+                    pk.TABLE_NAME AS PkTable,
+                    pt.COLUMN_NAME AS PkColumn
+                FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
+                JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS fk ON rc.CONSTRAINT_NAME = fk.CONSTRAINT_NAME
+                JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS pk ON rc.UNIQUE_CONSTRAINT_NAME = pk.CONSTRAINT_NAME
+                JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu ON rc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+                JOIN (
+                    SELECT i1.TABLE_NAME, i2.COLUMN_NAME
+                    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS i1
+                    JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE i2 ON i1.CONSTRAINT_NAME = i2.CONSTRAINT_NAME
+                    WHERE i1.CONSTRAINT_TYPE = 'PRIMARY KEY'
+                ) PT ON PT.TABLE_NAME = pk.TABLE_NAME
+                WHERE fk.TABLE_NAME = @TableName AND fk.TABLE_SCHEMA = @TableSchema", connection);
+
+        command.Parameters.AddWithValue("@TableName", tableName);
+        command.Parameters.AddWithValue("@TableSchema", tableSchema);
+
+        using (var reader = await command.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+            {
+                foreignKeys.Add(new ForeignKeySchema
+                {
+                    TableName = reader["FkTable"].ToString()!,
+                    ColumnName = reader["FkColumn"].ToString()!,
+                    ForeignTableName = reader["PkTable"].ToString()!,
+                    ForeignColumnName = reader["PkColumn"].ToString()!
+                });
+            }
+        }
+        return foreignKeys;
+    }
+
+    // --- NEW METHOD: Get Indexes ---
+    private async Task<List<IndexSchema>> GetIndexesForTableAsync(SqlConnection connection, string tableName, string tableSchema)
+    {
+        var indexes = new List<IndexSchema>();
+        var command = new SqlCommand($"EXEC sp_helpindex '{tableSchema}.{tableName}'", connection);
+
+        try
+        {
             using (var reader = await command.ExecuteReaderAsync())
             {
                 while (await reader.ReadAsync())
                 {
-                    primaryKeys.Add(reader["COLUMN_NAME"].ToString()!);
+                    string indexDescription = reader["index_description"].ToString()!;
+
+                    // IMPORTANT: Skip primary key and unique constraints, as they are handled elsewhere.
+                    if (indexDescription.Contains("primary key") || indexDescription.Contains("unique constraint"))
+                    {
+                        continue;
+                    }
+
+                    var index = new IndexSchema
+                    {
+                        IndexName = reader["index_name"].ToString()!,
+                        IsUnique = indexDescription.Contains("unique")
+                    };
+
+                    string keyString = reader["index_keys"].ToString()!;
+                    var keyParts = keyString.Split(new[] { ", " }, StringSplitOptions.RemoveEmptyEntries);
+
+                    foreach (var keyPart in keyParts)
+                    {
+                        var col = new IndexColumn();
+                        // Check if the column is descending
+                        if (keyPart.Contains("(-)"))
+                        {
+                            col.ColumnName = keyPart.Replace("(-)", "").Trim();
+                            col.IsAscending = false;
+                        }
+                        else
+                        {
+                            col.ColumnName = keyPart.Trim();
+                            col.IsAscending = true;
+                        }
+                        index.Columns.Add(col);
+                    }
+                    indexes.Add(index);
                 }
             }
-            return primaryKeys;
         }
+        catch (SqlException)
+        {
+            // sp_helpindex can throw an exception if the object isn't a table (e.g., a view).
+            // We can safely ignore this and return an empty list.
+        }
+        return indexes;
     }
+}

--- a/DbRosetta.Core/READERS/SqlServerSchemaReader.cs
+++ b/DbRosetta.Core/READERS/SqlServerSchemaReader.cs
@@ -25,32 +25,35 @@ public class SqlServerSchemaReader : IDatabaseSchemaReader
             }
         }
 
-        // Now, for each table, get its detailed schema
         foreach (var table in tables)
         {
-            table.Columns = await GetColumnsForTableAsync(sqlConnection, table.TableName);
-            table.PrimaryKey = await GetPrimaryKeyForTableAsync(sqlConnection, table.TableName);
+            table.Columns = await GetColumnsForTableAsync(sqlConnection, table.TableName, table.TableSchemaName);
+            table.PrimaryKey = await GetPrimaryKeyForTableAsync(sqlConnection, table.TableName, table.TableSchemaName);
             table.ForeignKeys = await GetForeignKeysForTableAsync(sqlConnection, table.TableName, table.TableSchemaName);
             table.Indexes = await GetIndexesForTableAsync(sqlConnection, table.TableName, table.TableSchemaName);
-
-            // --- ENHANCEMENT: Read Check Constraints ---
             table.CheckConstraints = await GetCheckConstraintsForTableAsync(sqlConnection, table.TableName, table.TableSchemaName);
+            table.UniqueConstraints = await GetUniqueConstraintsForTableAsync(sqlConnection, table.TableName, table.TableSchemaName);
+            table.Triggers = await GetTriggersForTableAsync(sqlConnection, table.TableName, table.TableSchemaName);
         }
 
         return tables;
     }
 
-    private async Task<List<ColumnSchema>> GetColumnsForTableAsync(SqlConnection connection, string tableName)
+    private async Task<List<ColumnSchema>> GetColumnsForTableAsync(SqlConnection connection, string tableName, string tableSchema)
     {
         var columns = new List<ColumnSchema>();
-        var command = new SqlCommand(@"
+        // ENHANCEMENT: Added COLUMNPROPERTY to check for the 'IsIdentity' flag.
+        var command = new SqlCommand($@"
                     SELECT
                         COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH,
-                        IS_NULLABLE, COLUMN_DEFAULT, NUMERIC_PRECISION, NUMERIC_SCALE
+                        IS_NULLABLE, COLUMN_DEFAULT, NUMERIC_PRECISION, NUMERIC_SCALE,
+                        COLUMNPROPERTY(object_id('[{tableSchema}].[{tableName}]'), COLUMN_NAME, 'IsIdentity') as IsIdentity
                     FROM INFORMATION_SCHEMA.COLUMNS
-                    WHERE TABLE_NAME = @TableName
+                    WHERE TABLE_NAME = @TableName AND TABLE_SCHEMA = @TableSchema
                     ORDER BY ORDINAL_POSITION", connection);
         command.Parameters.AddWithValue("@TableName", tableName);
+        command.Parameters.AddWithValue("@TableSchema", tableSchema);
+
         using (var reader = await command.ExecuteReaderAsync())
         {
             while (await reader.ReadAsync())
@@ -63,17 +66,18 @@ public class SqlServerSchemaReader : IDatabaseSchemaReader
                     IsNullable = reader["IS_NULLABLE"].ToString()!.Equals("YES", StringComparison.OrdinalIgnoreCase),
                     DefaultValue = reader["COLUMN_DEFAULT"]?.ToString() ?? string.Empty,
                     Precision = reader["NUMERIC_PRECISION"] != DBNull.Value ? Convert.ToInt32(reader["NUMERIC_PRECISION"]) : 0,
-                    Scale = reader["NUMERIC_SCALE"] != DBNull.Value ? Convert.ToInt32(reader["NUMERIC_SCALE"]) : 0
+                    Scale = reader["NUMERIC_SCALE"] != DBNull.Value ? Convert.ToInt32(reader["NUMERIC_SCALE"]) : 0,
+                    IsIdentity = reader["IsIdentity"] != DBNull.Value && Convert.ToInt32(reader["IsIdentity"]) == 1
                 });
             }
         }
         return columns;
     }
 
-    private async Task<List<string>> GetPrimaryKeyForTableAsync(SqlConnection connection, string tableName)
+    private async Task<List<string>> GetPrimaryKeyForTableAsync(SqlConnection connection, string tableName, string tableSchema)
     {
         var primaryKeys = new List<string>();
-        var command = new SqlCommand($"EXEC sp_pkeys @table_name = '{tableName}'", connection);
+        var command = new SqlCommand($"EXEC sp_pkeys @table_name = '{tableName}', @table_owner = '{tableSchema}'", connection);
         using (var reader = await command.ExecuteReaderAsync())
         {
             while (await reader.ReadAsync())
@@ -84,19 +88,21 @@ public class SqlServerSchemaReader : IDatabaseSchemaReader
         return primaryKeys;
     }
 
-    /// <summary>
-    /// Retrieves CHECK constraint clauses for a specific table.
-    /// </summary>
-    private async Task<List<string>> GetCheckConstraintsForTableAsync(SqlConnection connection, string tableName, string tableSchema)
+    private async Task<List<UniqueConstraintSchema>> GetUniqueConstraintsForTableAsync(SqlConnection connection, string tableName, string tableSchema)
     {
-        var constraints = new List<string>();
+        var constraints = new Dictionary<string, UniqueConstraintSchema>();
         var command = new SqlCommand(@"
-                    SELECT cc.CHECK_CLAUSE
-                    FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc
-                    INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc 
-                        ON cc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
-                        AND cc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA
-                    WHERE tc.TABLE_NAME = @TableName AND tc.TABLE_SCHEMA = @TableSchema", connection);
+                    SELECT
+                        tc.CONSTRAINT_NAME,
+                        kcu.COLUMN_NAME
+                    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc
+                    JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu
+                        ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+                        AND tc.CONSTRAINT_SCHEMA = kcu.CONSTRAINT_SCHEMA
+                    WHERE tc.CONSTRAINT_TYPE = 'UNIQUE'
+                      AND tc.TABLE_NAME = @TableName
+                      AND tc.TABLE_SCHEMA = @TableSchema
+                    ORDER BY tc.CONSTRAINT_NAME, kcu.ORDINAL_POSITION;", connection);
 
         command.Parameters.AddWithValue("@TableName", tableName);
         command.Parameters.AddWithValue("@TableSchema", tableSchema);
@@ -105,21 +111,66 @@ public class SqlServerSchemaReader : IDatabaseSchemaReader
         {
             while (await reader.ReadAsync())
             {
-                if (reader["CHECK_CLAUSE"] != DBNull.Value)
+                string constraintName = reader["CONSTRAINT_NAME"].ToString()!;
+                if (!constraints.ContainsKey(constraintName))
                 {
-                    constraints.Add(reader["CHECK_CLAUSE"].ToString()!);
+                    constraints[constraintName] = new UniqueConstraintSchema { ConstraintName = constraintName };
+                }
+                constraints[constraintName].Columns.Add(reader["COLUMN_NAME"].ToString()!);
+            }
+        }
+        return constraints.Values.ToList();
+    }
+
+    private async Task<List<TriggerSchema>> GetTriggersForTableAsync(SqlConnection connection, string tableName, string tableSchema)
+    {
+        var triggers = new List<TriggerSchema>();
+        var command = new SqlCommand(@"
+                SELECT
+                    tr.name AS TriggerName,
+                    sm.definition AS TriggerBody,
+                    CASE WHEN OBJECTPROPERTY(tr.object_id, 'ExecIsUpdateTrigger') = 1 THEN 'Update' ELSE '' END AS IsUpdate,
+                    CASE WHEN OBJECTPROPERTY(tr.object_id, 'ExecIsDeleteTrigger') = 1 THEN 'Delete' ELSE '' END AS IsDelete,
+                    CASE WHEN OBJECTPROPERTY(tr.object_id, 'ExecIsInsertTrigger') = 1 THEN 'Insert' ELSE '' END AS IsInsert,
+                    CASE WHEN OBJECTPROPERTY(tr.object_id, 'ExecIsInsteadOfTrigger') = 1 THEN 'InsteadOf' ELSE 'After' END AS TriggerType
+                FROM sys.triggers AS tr
+                JOIN sys.objects AS o ON tr.parent_id = o.object_id
+                JOIN sys.sql_modules AS sm ON tr.object_id = sm.object_id
+                WHERE o.name = @TableName AND SCHEMA_NAME(o.schema_id) = @TableSchema;", connection);
+
+        command.Parameters.AddWithValue("@TableName", tableName);
+        command.Parameters.AddWithValue("@TableSchema", tableSchema);
+
+        using (var reader = await command.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+            {
+                // A trigger can be for multiple events (e.g., FOR INSERT, UPDATE)
+                var events = new[] { reader["IsInsert"].ToString(), reader["IsUpdate"].ToString(), reader["IsDelete"].ToString() };
+                foreach (var ev in events)
+                {
+                    if (string.IsNullOrEmpty(ev)) continue;
+
+                    triggers.Add(new TriggerSchema
+                    {
+                        Name = reader["TriggerName"].ToString()!,
+                        Table = tableName,
+                        Body = reader["TriggerBody"].ToString()!,
+                        Event = (TriggerEvent)Enum.Parse(typeof(TriggerEvent), ev),
+                        Type = (TriggerType)Enum.Parse(typeof(TriggerType), reader["TriggerType"].ToString()!)
+                    });
                 }
             }
         }
-        return constraints;
+        return triggers;
     }
 
+    // Other methods (GetForeignKeysForTableAsync, etc.) remain the same...
     private async Task<List<ForeignKeySchema>> GetForeignKeysForTableAsync(SqlConnection connection, string tableName, string tableSchema)
     {
         var foreignKeys = new List<ForeignKeySchema>();
-        // This query correctly joins the necessary views to map foreign key columns to their primary key counterparts.
         var command = new SqlCommand(@"
-                SELECT 
+                SELECT
                     fk.TABLE_NAME AS FkTable,
                     kcu.COLUMN_NAME AS FkColumn,
                     pk.TABLE_NAME AS PkTable,
@@ -135,10 +186,8 @@ public class SqlServerSchemaReader : IDatabaseSchemaReader
                     WHERE i1.CONSTRAINT_TYPE = 'PRIMARY KEY'
                 ) PT ON PT.TABLE_NAME = pk.TABLE_NAME
                 WHERE fk.TABLE_NAME = @TableName AND fk.TABLE_SCHEMA = @TableSchema", connection);
-
         command.Parameters.AddWithValue("@TableName", tableName);
         command.Parameters.AddWithValue("@TableSchema", tableSchema);
-
         using (var reader = await command.ExecuteReaderAsync())
         {
             while (await reader.ReadAsync())
@@ -154,12 +203,10 @@ public class SqlServerSchemaReader : IDatabaseSchemaReader
         }
         return foreignKeys;
     }
-
     private async Task<List<IndexSchema>> GetIndexesForTableAsync(SqlConnection connection, string tableName, string tableSchema)
     {
         var indexes = new List<IndexSchema>();
         var command = new SqlCommand($"EXEC sp_helpindex '{tableSchema}.{tableName}'", connection);
-
         try
         {
             using (var reader = await command.ExecuteReaderAsync())
@@ -167,33 +214,23 @@ public class SqlServerSchemaReader : IDatabaseSchemaReader
                 while (await reader.ReadAsync())
                 {
                     string indexDescription = reader["index_description"].ToString()!;
-
                     if (indexDescription.Contains("primary key") || indexDescription.Contains("unique constraint"))
                     {
                         continue;
                     }
-
-                    var index = new IndexSchema
-                    {
-                        IndexName = reader["index_name"].ToString()!,
-                        IsUnique = indexDescription.Contains("unique")
-                    };
-
+                    var index = new IndexSchema { IndexName = reader["index_name"].ToString()!, IsUnique = indexDescription.Contains("unique") };
                     string keyString = reader["index_keys"].ToString()!;
                     var keyParts = keyString.Split(new[] { ", " }, StringSplitOptions.RemoveEmptyEntries);
-
                     foreach (var keyPart in keyParts)
                     {
                         var col = new IndexColumn();
                         if (keyPart.Contains("(-)"))
                         {
-                            col.ColumnName = keyPart.Replace("(-)", "").Trim();
-                            col.IsAscending = false;
+                            col.ColumnName = keyPart.Replace("(-)", "").Trim(); col.IsAscending = false;
                         }
                         else
                         {
-                            col.ColumnName = keyPart.Trim();
-                            col.IsAscending = true;
+                            col.ColumnName = keyPart.Trim(); col.IsAscending = true;
                         }
                         index.Columns.Add(col);
                     }
@@ -201,10 +238,28 @@ public class SqlServerSchemaReader : IDatabaseSchemaReader
                 }
             }
         }
-        catch (SqlException)
-        {
-            // sp_helpindex can throw if the object isn't a table. Ignore this and return an empty list.
-        }
+        catch (SqlException) { /* Ignore */ }
         return indexes;
+    }
+    private async Task<List<string>> GetCheckConstraintsForTableAsync(SqlConnection connection, string tableName, string tableSchema)
+    {
+        var constraints = new List<string>();
+        var command = new SqlCommand(@"
+                    SELECT cc.CHECK_CLAUSE FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc
+                    INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON cc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND cc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA
+                    WHERE tc.TABLE_NAME = @TableName AND tc.TABLE_SCHEMA = @TableSchema", connection);
+        command.Parameters.AddWithValue("@TableName", tableName);
+        command.Parameters.AddWithValue("@TableSchema", tableSchema);
+        using (var reader = await command.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+            {
+                if (reader["CHECK_CLAUSE"] != DBNull.Value)
+                {
+                    constraints.Add(reader["CHECK_CLAUSE"].ToString()!);
+                }
+            }
+        }
+        return constraints;
     }
 }

--- a/DbRosetta.Core/SERVICES/DataMigratorService.cs
+++ b/DbRosetta.Core/SERVICES/DataMigratorService.cs
@@ -1,121 +1,110 @@
 ﻿using System.Data.Common;
 using System.Text;
-using System.Text.RegularExpressions; // Required for parameter name normalization
-using Microsoft.Data.Sqlite; // Required for SQLite-specific PRAGMA commands
+using System.Text.RegularExpressions;
+using Microsoft.Data.Sqlite;
 
-    public class DataMigrator : IDataMigrator
+public class DataMigrator : IDataMigrator
+{
+    private const string SqlGeographyTypeName = "Microsoft.SqlServer.Types.SqlGeography";
+    private const string SqlGeometryTypeName = "Microsoft.SqlServer.Types.SqlGeometry";
+    private const string SqlHierarchyIdTypeName = "Microsoft.SqlServer.Types.SqlHierarchyId";
+
+    public async Task MigrateDataAsync(
+        DbConnection sourceConnection,
+        DbConnection destinationConnection,
+        List<TableSchema> tables,
+        Action<string, long> progressAction)
     {
-        // Define the type names as constants for clarity and maintainability
-        private const string SqlGeographyTypeName = "Microsoft.SqlServer.Types.SqlGeography";
-        private const string SqlGeometryTypeName = "Microsoft.SqlServer.Types.SqlGeometry";
-        private const string SqlHierarchyIdTypeName = "Microsoft.SqlServer.Types.SqlHierarchyId";
-
-        public async Task MigrateDataAsync(
-            DbConnection sourceConnection,
-            DbConnection destinationConnection,
-            List<TableSchema> tables,
-            Action<string, long> progressAction)
+        if (!(destinationConnection is SqliteConnection sqliteConnection))
         {
-            if (!(destinationConnection is SqliteConnection sqliteConnection))
-            {
-                throw new ArgumentException("A SqliteConnection is required for this data migrator.", nameof(destinationConnection));
-            }
+            throw new ArgumentException("A SqliteConnection is required for this data migrator.", nameof(destinationConnection));
+        }
 
-            // FIX 1: Disable foreign keys before starting the bulk data load to solve dependency order issues.
-            var pragmaCommand = sqliteConnection.CreateCommand();
-            pragmaCommand.CommandText = "PRAGMA foreign_keys = OFF;";
-            await pragmaCommand.ExecuteNonQueryAsync();
+        var pragmaCommand = sqliteConnection.CreateCommand();
+        pragmaCommand.CommandText = "PRAGMA foreign_keys = OFF;";
+        await pragmaCommand.ExecuteNonQueryAsync();
 
-            try
+        try
+        {
+            foreach (var table in tables)
             {
-                foreach (var table in tables)
+                long rowsMigrated = 0;
+
+                var selectCommand = sourceConnection.CreateCommand();
+                selectCommand.CommandText = $"SELECT * FROM [{table.TableSchemaName}].[{table.TableName}]";
+
+                var insertCommand = BuildInsertCommand(destinationConnection, table);
+
+                await using var reader = await selectCommand.ExecuteReaderAsync();
+                await using var transaction = await destinationConnection.BeginTransactionAsync();
+                insertCommand.Transaction = transaction;
+
+                while (await reader.ReadAsync())
                 {
-                    long rowsMigrated = 0;
-
-                    var selectCommand = sourceConnection.CreateCommand();
-                    selectCommand.CommandText = $"SELECT * FROM [{table.TableSchemaName}].[{table.TableName}]";
-
-                    // This now builds a command with sanitized parameter names
-                    var insertCommand = BuildInsertCommand(destinationConnection, table);
-
-                    await using var reader = await selectCommand.ExecuteReaderAsync();
-                    await using var transaction = await destinationConnection.BeginTransactionAsync();
-                    insertCommand.Transaction = transaction;
-
-                    while (await reader.ReadAsync())
+                    insertCommand.Parameters.Clear();
+                    for (int i = 0; i < table.Columns.Count; i++)
                     {
-                        insertCommand.Parameters.Clear();
-                        for (int i = 0; i < table.Columns.Count; i++)
+                        var columnName = table.Columns[i].ColumnName;
+                        var value = reader[columnName];
+
+                        var finalValue = value;
+                        string? valueTypeName = value?.GetType().FullName;
+                        if (valueTypeName == SqlGeographyTypeName ||
+                            valueTypeName == SqlGeometryTypeName ||
+                            valueTypeName == SqlHierarchyIdTypeName)
                         {
-                            var columnName = table.Columns[i].ColumnName;
-                            var value = reader[columnName];
-
-                            // FIX 2: Intercept and convert special User-Defined Types to strings
-                            var finalValue = value;
-                            string? valueTypeName = value?.GetType().FullName;
-                            if (valueTypeName == SqlGeographyTypeName ||
-                                valueTypeName == SqlGeometryTypeName ||
-                                valueTypeName == SqlHierarchyIdTypeName)
-                            {
-                                finalValue = value?.ToString();
-                            }
-
-                            var parameter = insertCommand.CreateParameter();
-
-                            // FIX 3: Use the NORMALIZED name for the parameter object
-                            parameter.ParameterName = NormalizeParameterName(columnName);
-
-                            parameter.Value = finalValue is DBNull || finalValue is null ? DBNull.Value : finalValue;
-                            insertCommand.Parameters.Add(parameter);
+                            finalValue = value?.ToString();
                         }
 
-                        await insertCommand.ExecuteNonQueryAsync();
-                        rowsMigrated++;
-
-                        if (rowsMigrated % 100 == 0)
+                        // --- FINAL FIX: Trim string values to remove padding from fixed-length types (char/nchar). ---
+                        // This is the crucial fix that solves the paradox.
+                        if (finalValue is string stringValue)
                         {
-                            progressAction(table.TableName, rowsMigrated);
+                            finalValue = stringValue.Trim();
                         }
+
+                        var parameter = insertCommand.CreateParameter();
+                        parameter.ParameterName = NormalizeParameterName(columnName);
+                        parameter.Value = finalValue is DBNull || finalValue is null ? DBNull.Value : finalValue;
+                        insertCommand.Parameters.Add(parameter);
                     }
 
-                    await transaction.CommitAsync();
-                    progressAction(table.TableName, rowsMigrated);
+                    await insertCommand.ExecuteNonQueryAsync();
+                    rowsMigrated++;
+
+                    if (rowsMigrated % 100 == 0)
+                    {
+                        progressAction(table.TableName, rowsMigrated);
+                    }
                 }
-            }
-            finally
-            {
-                // ALWAYS re-enable foreign keys after the process, even if it fails.
-                pragmaCommand.CommandText = "PRAGMA foreign_keys = ON;";
-                await pragmaCommand.ExecuteNonQueryAsync();
+
+                await transaction.CommitAsync();
+                progressAction(table.TableName, rowsMigrated);
             }
         }
-
-        private DbCommand BuildInsertCommand(DbConnection connection, TableSchema table)
+        finally
         {
-            var command = connection.CreateCommand();
-            var sb = new StringBuilder();
-
-            sb.Append($"INSERT INTO [{table.TableName}] (");
-            sb.Append(string.Join(", ", table.Columns.Select(c => $"[{c.ColumnName}]")));
-            sb.Append(") VALUES (");
-
-            // FIX 3: Use the NORMALIZED names when building the VALUES clause
-            sb.Append(string.Join(", ", table.Columns.Select(c => NormalizeParameterName(c.ColumnName))));
-
-            sb.Append(");");
-            command.CommandText = sb.ToString();
-            return command;
-        }
-
-        /// <summary>
-        /// Creates a safe parameter name from a column name by replacing invalid characters.
-        /// This prevents SQL syntax errors for columns with spaces or special characters.
-        /// </summary>
-        /// <param name="columnName">The original column name.</param>
-        /// <returns>A sanitized string suitable for use as a parameter name (e.g., "@Address_Line_1").</returns>
-        private string NormalizeParameterName(string columnName)
-        {
-            // Prepends "@" and replaces any character that is not a letter, digit, or underscore with an underscore.
-            return "@" + Regex.Replace(columnName, @"[^\w]", "_");
+            pragmaCommand.CommandText = "PRAGMA foreign_keys = ON;";
+            await pragmaCommand.ExecuteNonQueryAsync();
         }
     }
+
+    private DbCommand BuildInsertCommand(DbConnection connection, TableSchema table)
+    {
+        var command = connection.CreateCommand();
+        var sb = new StringBuilder();
+
+        sb.Append($"INSERT INTO [{table.TableName}] (");
+        sb.Append(string.Join(", ", table.Columns.Select(c => $"[{c.ColumnName}]")));
+        sb.Append(") VALUES (");
+        sb.Append(string.Join(", ", table.Columns.Select(c => NormalizeParameterName(c.ColumnName))));
+        sb.Append(");");
+        command.CommandText = sb.ToString();
+        return command;
+    }
+
+    private string NormalizeParameterName(string columnName)
+    {
+        return "@" + Regex.Replace(columnName, @"[^\w]", "_");
+    }
+}

--- a/DbRosetta.Core/SERVICES/DataMigratorService.cs
+++ b/DbRosetta.Core/SERVICES/DataMigratorService.cs
@@ -1,0 +1,121 @@
+﻿using System.Data.Common;
+using System.Text;
+using System.Text.RegularExpressions; // Required for parameter name normalization
+using Microsoft.Data.Sqlite; // Required for SQLite-specific PRAGMA commands
+
+    public class DataMigrator : IDataMigrator
+    {
+        // Define the type names as constants for clarity and maintainability
+        private const string SqlGeographyTypeName = "Microsoft.SqlServer.Types.SqlGeography";
+        private const string SqlGeometryTypeName = "Microsoft.SqlServer.Types.SqlGeometry";
+        private const string SqlHierarchyIdTypeName = "Microsoft.SqlServer.Types.SqlHierarchyId";
+
+        public async Task MigrateDataAsync(
+            DbConnection sourceConnection,
+            DbConnection destinationConnection,
+            List<TableSchema> tables,
+            Action<string, long> progressAction)
+        {
+            if (!(destinationConnection is SqliteConnection sqliteConnection))
+            {
+                throw new ArgumentException("A SqliteConnection is required for this data migrator.", nameof(destinationConnection));
+            }
+
+            // FIX 1: Disable foreign keys before starting the bulk data load to solve dependency order issues.
+            var pragmaCommand = sqliteConnection.CreateCommand();
+            pragmaCommand.CommandText = "PRAGMA foreign_keys = OFF;";
+            await pragmaCommand.ExecuteNonQueryAsync();
+
+            try
+            {
+                foreach (var table in tables)
+                {
+                    long rowsMigrated = 0;
+
+                    var selectCommand = sourceConnection.CreateCommand();
+                    selectCommand.CommandText = $"SELECT * FROM [{table.TableSchemaName}].[{table.TableName}]";
+
+                    // This now builds a command with sanitized parameter names
+                    var insertCommand = BuildInsertCommand(destinationConnection, table);
+
+                    await using var reader = await selectCommand.ExecuteReaderAsync();
+                    await using var transaction = await destinationConnection.BeginTransactionAsync();
+                    insertCommand.Transaction = transaction;
+
+                    while (await reader.ReadAsync())
+                    {
+                        insertCommand.Parameters.Clear();
+                        for (int i = 0; i < table.Columns.Count; i++)
+                        {
+                            var columnName = table.Columns[i].ColumnName;
+                            var value = reader[columnName];
+
+                            // FIX 2: Intercept and convert special User-Defined Types to strings
+                            var finalValue = value;
+                            string? valueTypeName = value?.GetType().FullName;
+                            if (valueTypeName == SqlGeographyTypeName ||
+                                valueTypeName == SqlGeometryTypeName ||
+                                valueTypeName == SqlHierarchyIdTypeName)
+                            {
+                                finalValue = value?.ToString();
+                            }
+
+                            var parameter = insertCommand.CreateParameter();
+
+                            // FIX 3: Use the NORMALIZED name for the parameter object
+                            parameter.ParameterName = NormalizeParameterName(columnName);
+
+                            parameter.Value = finalValue is DBNull || finalValue is null ? DBNull.Value : finalValue;
+                            insertCommand.Parameters.Add(parameter);
+                        }
+
+                        await insertCommand.ExecuteNonQueryAsync();
+                        rowsMigrated++;
+
+                        if (rowsMigrated % 100 == 0)
+                        {
+                            progressAction(table.TableName, rowsMigrated);
+                        }
+                    }
+
+                    await transaction.CommitAsync();
+                    progressAction(table.TableName, rowsMigrated);
+                }
+            }
+            finally
+            {
+                // ALWAYS re-enable foreign keys after the process, even if it fails.
+                pragmaCommand.CommandText = "PRAGMA foreign_keys = ON;";
+                await pragmaCommand.ExecuteNonQueryAsync();
+            }
+        }
+
+        private DbCommand BuildInsertCommand(DbConnection connection, TableSchema table)
+        {
+            var command = connection.CreateCommand();
+            var sb = new StringBuilder();
+
+            sb.Append($"INSERT INTO [{table.TableName}] (");
+            sb.Append(string.Join(", ", table.Columns.Select(c => $"[{c.ColumnName}]")));
+            sb.Append(") VALUES (");
+
+            // FIX 3: Use the NORMALIZED names when building the VALUES clause
+            sb.Append(string.Join(", ", table.Columns.Select(c => NormalizeParameterName(c.ColumnName))));
+
+            sb.Append(");");
+            command.CommandText = sb.ToString();
+            return command;
+        }
+
+        /// <summary>
+        /// Creates a safe parameter name from a column name by replacing invalid characters.
+        /// This prevents SQL syntax errors for columns with spaces or special characters.
+        /// </summary>
+        /// <param name="columnName">The original column name.</param>
+        /// <returns>A sanitized string suitable for use as a parameter name (e.g., "@Address_Line_1").</returns>
+        private string NormalizeParameterName(string columnName)
+        {
+            // Prepends "@" and replaces any character that is not a letter, digit, or underscore with an underscore.
+            return "@" + Regex.Replace(columnName, @"[^\w]", "_");
+        }
+    }

--- a/DbRosetta.Core/WRITERS/SQLiteWriter.cs
+++ b/DbRosetta.Core/WRITERS/SQLiteWriter.cs
@@ -30,20 +30,33 @@ public class SQLiteWriter : IDatabaseWriter
             }
             catch (SqliteException ex)
             {
-                throw new Exception($"Failed to create table '{table.TableName}'. Review the generated script for syntax errors.\n--- SCRIPT START ---\n{createTableScript}\n--- SCRIPT END ---", ex);
+                throw new Exception($"Failed to create table '{table.TableName}'. Review generated script.\n--- SCRIPT START ---\n{createTableScript}\n--- SCRIPT END ---", ex);
             }
         }
-    }
 
-    public async Task WriteDataAsync(DbConnection sourceConnection, DbConnection destinationConnection, List<TableSchema> tables)
-    {
-        await Task.CompletedTask;
+        foreach (var table in tables)
+        {
+            foreach (var trigger in table.Triggers)
+            {
+                string createTriggerScript = BuildCreateTriggerScript(trigger);
+                var triggerCommand = new SqliteCommand(createTriggerScript, sqliteConnection);
+                try
+                {
+                    await triggerCommand.ExecuteNonQueryAsync();
+                }
+                catch (SqliteException ex)
+                {
+                    throw new Exception($"Failed to create trigger '{trigger.Name}' on table '{trigger.Table}'.\n--- SCRIPT START ---\n{createTriggerScript}\n--- SCRIPT END ---", ex);
+                }
+            }
+        }
     }
 
     private string BuildCreateTableScript(TableSchema ts, TypeMappingService typeService, string sourceDialectName)
     {
         var sb = new StringBuilder();
         var allDefinitions = new List<string>();
+        bool isPkDefinedInline = false;
 
         sb.AppendLine($"CREATE TABLE [{ts.TableName}] (");
 
@@ -53,32 +66,37 @@ public class SQLiteWriter : IDatabaseWriter
             var dbColInfo = new DbColumnInfo() { TypeName = col.ColumnType, Length = col.Length, Precision = col.Precision, Scale = col.Scale };
             string targetType = typeService.TranslateType(dbColInfo, sourceDialectName, "SQLite") ?? "TEXT";
             columnLine.Append($"    [{col.ColumnName}] {targetType}");
+            if (col.IsIdentity && ts.PrimaryKey.Count == 1 && ts.PrimaryKey[0] == col.ColumnName)
+            {
+                columnLine.Append(" PRIMARY KEY AUTOINCREMENT");
+                isPkDefinedInline = true;
+            }
             if (!col.IsNullable) columnLine.Append(" NOT NULL");
             if (!string.IsNullOrWhiteSpace(col.DefaultValue))
             {
-                string defaultValue = TranslateSqlServerExpressionToSQLite(col.DefaultValue, isDefaultConstraint: true);
+                string defaultValue = TranslateSqlServerExpressionToSQLite(col.DefaultValue, true);
                 columnLine.Append($" DEFAULT {defaultValue}");
             }
             allDefinitions.Add(columnLine.ToString());
         }
 
-        if (ts.PrimaryKey.Any())
+        if (!isPkDefinedInline && ts.PrimaryKey.Any())
         {
-            var pkCols = string.Join(", ", ts.PrimaryKey.Select(c => $"[{c}]"));
-            allDefinitions.Add($"    PRIMARY KEY ({pkCols})");
+            allDefinitions.Add($"    PRIMARY KEY ({string.Join(", ", ts.PrimaryKey.Select(c => $"[{c}]"))})");
         }
-
+        foreach (var uc in ts.UniqueConstraints)
+        {
+            allDefinitions.Add($"    UNIQUE ({string.Join(", ", uc.Columns.Select(c => $"[{c}]"))})");
+        }
         foreach (var fk in ts.ForeignKeys)
         {
             allDefinitions.Add($"    FOREIGN KEY ([{fk.ColumnName}]) REFERENCES [{fk.ForeignTableName}] ([{fk.ForeignColumnName}])");
         }
-
         if (ts.CheckConstraints.Any())
         {
             foreach (var checkClause in ts.CheckConstraints)
             {
-                string translatedClause = TranslateSqlServerExpressionToSQLite(checkClause, isDefaultConstraint: false);
-                allDefinitions.Add($"    CHECK ({translatedClause})");
+                allDefinitions.Add($"    CHECK ({TranslateSqlServerExpressionToSQLite(checkClause, false)})");
             }
         }
 
@@ -93,50 +111,80 @@ public class SQLiteWriter : IDatabaseWriter
         sb.Append("CREATE ");
         if (index.IsUnique) sb.Append("UNIQUE ");
         sb.Append($"INDEX [{index.IndexName}] ON [{tableName}] (");
-        var indexCols = index.Columns.Select(c => $"[{c.ColumnName}]" + (c.IsAscending ? "" : " DESC"));
-        sb.Append(string.Join(", ", indexCols));
+        sb.Append(string.Join(", ", index.Columns.Select(c => $"[{c.ColumnName}]" + (c.IsAscending ? "" : " DESC"))));
         sb.Append(");");
+        return sb.ToString();
+    }
+
+    private string BuildCreateTriggerScript(TriggerSchema trigger)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine($"CREATE TRIGGER IF NOT EXISTS [{trigger.Name}]");
+
+        string triggerTypeClause = trigger.Type == TriggerType.InsteadOf ? "INSTEAD OF" : "AFTER";
+
+        if (trigger.Type == TriggerType.InsteadOf)
+        {
+            sb.AppendLine($"    AFTER {trigger.Event.ToString().ToUpper()} ON [{trigger.Table}] -- MIGRATION WARNING: Was INSTEAD OF");
+        }
+        else
+        {
+            sb.AppendLine($"    {triggerTypeClause} {trigger.Event.ToString().ToUpper()} ON [{trigger.Table}]");
+        }
+
+        sb.AppendLine("    FOR EACH ROW\nBEGIN");
+
+        // --- FINAL FIX: Add a properly terminated, harmless statement to ensure the trigger body is not empty. ---
+        sb.AppendLine("    SELECT 1; -- This is a placeholder to ensure the trigger is syntactically valid.");
+
+        sb.AppendLine();
+        if (trigger.Type == TriggerType.InsteadOf)
+        {
+            sb.AppendLine("    -- # MIGRATION WARNING: SQLite only supports INSTEAD OF triggers on VIEWs.");
+            sb.AppendLine("    -- # This trigger has been created as a placeholder AFTER trigger.");
+            sb.AppendLine("    -- # The original logic must be manually reviewed and adapted.");
+        }
+        else
+        {
+            sb.AppendLine("    -- The original T-SQL body below must be manually translated to SQLite syntax.");
+        }
+
+        sb.AppendLine("    -- --- ORIGINAL SQL SERVER TRIGGER ---");
+
+        var bodyLines = trigger.Body.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+        foreach (var line in bodyLines)
+        {
+            sb.AppendLine($"    -- {line}");
+        }
+
+        sb.AppendLine("END;");
+
         return sb.ToString();
     }
 
     private string TranslateSqlServerExpressionToSQLite(string expression, bool isDefaultConstraint)
     {
         if (string.IsNullOrWhiteSpace(expression)) return string.Empty;
-
         string workExpression = expression.Trim();
 
         if (isDefaultConstraint)
         {
-            Match match = Regex.Match(workExpression, @"^\(\((-?\d+(\.\d+)?)\)\)$");
-            if (match.Success) return match.Groups[1].Value;
-
-            match = Regex.Match(workExpression, @"^\(N?'(.*)'\)$");
-            if (match.Success) return $"'{match.Groups[1].Value.Replace("'", "''")}'";
-
+            Match match = Regex.Match(workExpression, @"^\(\((-?\d+(\.\d+)?)\)\)$"); if (match.Success) return match.Groups[1].Value;
+            match = Regex.Match(workExpression, @"^\(N?'(.*)'\)$"); if (match.Success) return $"'{match.Groups[1].Value.Replace("'", "''")}'";
             if (Regex.IsMatch(workExpression, @"^\((getdate|sysdatetime)\(\)\)$", RegexOptions.IgnoreCase)) return "CURRENT_TIMESTAMP";
             if (Regex.IsMatch(workExpression, @"^\(newid\(\)\)$", RegexOptions.IgnoreCase)) return "(lower(hex(randomblob(16))))";
-
-            match = Regex.Match(workExpression, @"^\(CONVERT\s*\(\s*\[?bit\]?\s*,\s*\(\s*([01])\s*\)\s*\)\)$", RegexOptions.IgnoreCase);
-            if (match.Success) return match.Groups[1].Value;
+            match = Regex.Match(workExpression, @"^\(CONVERT\s*\(\s*\[?bit\]?\s*,\s*\(\s*([01])\s*\)\s*\)\)$", RegexOptions.IgnoreCase); if (match.Success) return match.Groups[1].Value;
         }
 
         string translated = workExpression;
         translated = Regex.Replace(translated, @"\bGETDATE\(\)", "CURRENT_TIMESTAMP", RegexOptions.IgnoreCase);
         translated = Regex.Replace(translated, @"\bSYSDATETIME\(\)", "CURRENT_TIMESTAMP", RegexOptions.IgnoreCase);
-        translated = Regex.Replace(translated, @"\bYEAR\((.*?)\)", "strftime('%Y', $1)", RegexOptions.IgnoreCase);
-        translated = Regex.Replace(translated, @"\bMONTH\((.*?)\)", "strftime('%m', $1)", RegexOptions.IgnoreCase);
-        translated = Regex.Replace(translated, @"\bDAY\((.*?)\)", "strftime('%d', $1)", RegexOptions.IgnoreCase);
         translated = Regex.Replace(translated, @"\bdateadd\s*\(\s*year\s*,\s*\(?(-?\d+)\)?\s*,\s*([^)]+)\)", "date($2, '$1 years')", RegexOptions.IgnoreCase);
         translated = Regex.Replace(translated, @"\bdateadd\s*\(\s*month\s*,\s*\(?(-?\d+)\)?\s*,\s*([^)]+)\)", "date($2, '$1 months')", RegexOptions.IgnoreCase);
         translated = Regex.Replace(translated, @"\bdateadd\s*\(\s*day\s*,\s*\(?(-?\d+)\)?\s*,\s*([^)]+)\)", "date($2, '$1 days')", RegexOptions.IgnoreCase);
-
-        // --- FINAL FIX: Translate SQL Server LIKE with character sets to SQLite GLOB and make it case-insensitive ---
-        // This pattern finds a column [ColName] followed by LIKE '[...]' and converts it to UPPER([ColName]) GLOB '[...]'
         translated = Regex.Replace(translated, @"(\[\w+\])\s+LIKE\s*('\[.*\]')", "UPPER($1) GLOB $2", RegexOptions.IgnoreCase);
-
-        // This handles any remaining simple LIKEs (not using '[...]') to be case-insensitive
         translated = Regex.Replace(translated, @"(\[\w+\])\s+LIKE", "UPPER($1) LIKE", RegexOptions.IgnoreCase);
-
 
         if (!isDefaultConstraint && translated.StartsWith("(") && translated.EndsWith(")"))
         {

--- a/DbRosetta.Core/WRITERS/SQLiteWriter.cs
+++ b/DbRosetta.Core/WRITERS/SQLiteWriter.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using Microsoft.Data.Sqlite;
 
+
 public class SQLiteWriter : IDatabaseWriter
 {
     public async Task WriteSchemaAsync(DbConnection connection, List<TableSchema> tables, TypeMappingService typeService, string sourceDialectName)
@@ -13,20 +14,27 @@ public class SQLiteWriter : IDatabaseWriter
 
         foreach (var table in tables)
         {
-            var createTableSql = BuildCreateTableQuery(table, typeService, sourceDialectName);
-            var command = new SqliteCommand(createTableSql, sqliteConnection);
+            var createTableScript = BuildCreateTableScript(table, typeService, sourceDialectName);
+            var command = new SqliteCommand(createTableScript, sqliteConnection);
             await command.ExecuteNonQueryAsync();
         }
     }
 
-    private string BuildCreateTableQuery(TableSchema ts, TypeMappingService typeService, string sourceDialectName)
+    private string BuildCreateTableScript(TableSchema ts, TypeMappingService typeService, string sourceDialectName)
     {
         var sb = new StringBuilder();
+        var constraints = new List<string>();
+
         sb.AppendLine($"CREATE TABLE [{ts.TableName}] (");
 
+        // 1. Define Columns
         for (int i = 0; i < ts.Columns.Count; i++)
         {
             var col = ts.Columns[i];
+
+            // ==========================================================
+            //  FIX: Populate the DbColumnInfo object correctly
+            // ==========================================================
             var sourceColumnInfo = new DbColumnInfo
             {
                 TypeName = col.ColumnType,
@@ -35,41 +43,57 @@ public class SQLiteWriter : IDatabaseWriter
                 Scale = col.Scale
             };
 
-            // Use the type service to translate the column type to SQLite!
             string targetType = typeService.TranslateType(sourceColumnInfo, sourceDialectName, "SQLite") ?? "TEXT";
 
-            sb.Append($"    [{col.ColumnName}] {targetType}");
-
+            var columnLine = new StringBuilder($"    [{col.ColumnName}] {targetType}");
             if (!col.IsNullable)
             {
-                sb.Append(" NOT NULL");
+                columnLine.Append(" NOT NULL");
             }
+            // (Default value logic can be expanded here)
 
-            // Simplified default value handling for now
-            if (!string.IsNullOrWhiteSpace(col.DefaultValue))
-            {
-                // Basic check to see if default is numeric or needs quotes
-                if (double.TryParse(col.DefaultValue, out _))
-                {
-                    sb.Append($" DEFAULT {col.DefaultValue}");
-                }
-                else
-                {
-                    sb.Append($" DEFAULT '{col.DefaultValue.Replace("'", "''")}'");
-                }
-            }
-
-            sb.AppendLine(i < ts.Columns.Count - 1 || ts.PrimaryKey.Any() ? "," : "");
+            sb.AppendLine(columnLine.ToString() + (i < ts.Columns.Count - 1 ? "," : ""));
         }
 
-        // Add primary keys
+        // 2. Define Primary Key Constraint
         if (ts.PrimaryKey.Any())
         {
             var pkColumns = string.Join(", ", ts.PrimaryKey.Select(pk => $"[{pk}]"));
-            sb.AppendLine($"    PRIMARY KEY ({pkColumns})");
+            constraints.Add($"    PRIMARY KEY ({pkColumns})");
+        }
+
+        // 3. Define Foreign Key Constraints
+        if (ts.ForeignKeys.Any())
+        {
+            foreach (var fk in ts.ForeignKeys)
+            {
+                constraints.Add($"    FOREIGN KEY ([{fk.ColumnName}]) REFERENCES [{fk.ForeignTableName}]([{fk.ForeignColumnName}])");
+            }
+        }
+
+        // 4. Append all constraints to the CREATE TABLE statement
+        if (constraints.Any())
+        {
+            sb.AppendLine(",");
+            sb.AppendLine(string.Join(",\n", constraints));
         }
 
         sb.AppendLine(");");
+
+        // 5. Append CREATE INDEX statements
+        if (ts.Indexes.Any())
+        {
+            foreach (var index in ts.Indexes)
+            {
+                string unique = index.IsUnique ? "UNIQUE" : "";
+                var indexColumns = string.Join(", ", index.Columns.Select(c => $"[{c.ColumnName}]" + (c.IsAscending ? "" : " DESC")));
+
+                var safeIndexName = $"IX_{ts.TableName}_{string.Join("_", index.Columns.Select(c => c.ColumnName))}";
+
+                sb.AppendLine($"CREATE {unique} INDEX IF NOT EXISTS [{safeIndexName}] ON [{ts.TableName}] ({indexColumns});");
+            }
+        }
+
         return sb.ToString();
     }
 }

--- a/DbRosetta.Core/WRITERS/SQLiteWriter.cs
+++ b/DbRosetta.Core/WRITERS/SQLiteWriter.cs
@@ -1,0 +1,75 @@
+﻿using System.Data.Common;
+using System.Text;
+using Microsoft.Data.Sqlite;
+
+public class SQLiteWriter : IDatabaseWriter
+{
+    public async Task WriteSchemaAsync(DbConnection connection, List<TableSchema> tables, TypeMappingService typeService, string sourceDialectName)
+    {
+        if (!(connection is SqliteConnection sqliteConnection))
+        {
+            throw new ArgumentException("A SqliteConnection is required.", nameof(connection));
+        }
+
+        foreach (var table in tables)
+        {
+            var createTableSql = BuildCreateTableQuery(table, typeService, sourceDialectName);
+            var command = new SqliteCommand(createTableSql, sqliteConnection);
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+
+    private string BuildCreateTableQuery(TableSchema ts, TypeMappingService typeService, string sourceDialectName)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"CREATE TABLE [{ts.TableName}] (");
+
+        for (int i = 0; i < ts.Columns.Count; i++)
+        {
+            var col = ts.Columns[i];
+            var sourceColumnInfo = new DbColumnInfo
+            {
+                TypeName = col.ColumnType,
+                Length = col.Length,
+                Precision = col.Precision,
+                Scale = col.Scale
+            };
+
+            // Use the type service to translate the column type to SQLite!
+            string targetType = typeService.TranslateType(sourceColumnInfo, sourceDialectName, "SQLite") ?? "TEXT";
+
+            sb.Append($"    [{col.ColumnName}] {targetType}");
+
+            if (!col.IsNullable)
+            {
+                sb.Append(" NOT NULL");
+            }
+
+            // Simplified default value handling for now
+            if (!string.IsNullOrWhiteSpace(col.DefaultValue))
+            {
+                // Basic check to see if default is numeric or needs quotes
+                if (double.TryParse(col.DefaultValue, out _))
+                {
+                    sb.Append($" DEFAULT {col.DefaultValue}");
+                }
+                else
+                {
+                    sb.Append($" DEFAULT '{col.DefaultValue.Replace("'", "''")}'");
+                }
+            }
+
+            sb.AppendLine(i < ts.Columns.Count - 1 || ts.PrimaryKey.Any() ? "," : "");
+        }
+
+        // Add primary keys
+        if (ts.PrimaryKey.Any())
+        {
+            var pkColumns = string.Join(", ", ts.PrimaryKey.Select(pk => $"[{pk}]"));
+            sb.AppendLine($"    PRIMARY KEY ({pkColumns})");
+        }
+
+        sb.AppendLine(");");
+        return sb.ToString();
+    }
+}

--- a/DbRosetta.ExampleConsoleApp/DbRosetta.ExampleConsoleApp.csproj
+++ b/DbRosetta.ExampleConsoleApp/DbRosetta.ExampleConsoleApp.csproj
@@ -11,4 +11,8 @@
     <ProjectReference Include="..\DbRosetta.Core\DbRosetta.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
+  </ItemGroup>
+
 </Project>

--- a/DbRosetta.ExampleConsoleApp/DbRosetta.ExampleConsoleApp.csproj
+++ b/DbRosetta.ExampleConsoleApp/DbRosetta.ExampleConsoleApp.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SqlServer.Types" Version="160.1000.6" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
   </ItemGroup>
 

--- a/DbRosetta.ExampleConsoleApp/Program.cs
+++ b/DbRosetta.ExampleConsoleApp/Program.cs
@@ -1,79 +1,88 @@
 ﻿using Microsoft.Data.SqlClient;
 using Microsoft.Data.Sqlite;
 
-
-internal class Program
+namespace DbRosetta.ExampleConsoleApp
 {
-    static async Task Main(string[] args)
+    internal class Program
     {
-        SQLitePCL.Batteries.Init();
-        Console.WriteLine("DbRosetta Universal Database Translator");
-        Console.WriteLine("---------------------------------------");
-
-        var sqlServerConnectionString = "Server=MSI\\SQLEXPRESS;Database=AdventureWorks2014;Trusted_Connection=True;TrustServerCertificate=True;";
-        var outputSqliteFile = "MyTranslatedDb.sqlite";
-
-        var typeService = new TypeMappingService(GetDialects());
-        var schemaReader = new SqlServerSchemaReader();
-        var schemaWriter = new SQLiteWriter();
-        var dataMigrator = new DataMigrator(); // Instantiate the new service
-
-        try
+        static async Task Main(string[] args)
         {
-            if (File.Exists(outputSqliteFile))
+            SQLitePCL.Batteries.Init();
+            Console.WriteLine("DbRosetta Universal Database Translator");
+            Console.WriteLine("---------------------------------------");
+
+            var sqlServerConnectionString = "Server=MSI\\SQLEXPRESS;Database=AdventureWorks2014;Trusted_Connection=True;TrustServerCertificate=True;";
+            var outputSqliteFile = "MyTranslatedDb.sqlite";
+
+            var typeService = new TypeMappingService(GetDialects());
+            var schemaReader = new SqlServerSchemaReader();
+            var schemaWriter = new SQLiteWriter();
+            var dataMigrator = new DataMigrator();
+
+            try
             {
-                File.Delete(outputSqliteFile);
-                Console.WriteLine($"Deleted existing file: {outputSqliteFile}");
+                if (File.Exists(outputSqliteFile))
+                {
+                    File.Delete(outputSqliteFile);
+                    Console.WriteLine($"Deleted existing file: {outputSqliteFile}");
+                }
+
+                await using var sqlConnection = new SqlConnection(sqlServerConnectionString);
+                await using var sqliteConnection = new SqliteConnection($"Data Source={outputSqliteFile}");
+                await sqlConnection.OpenAsync();
+                await sqliteConnection.OpenAsync();
+                Console.WriteLine("Successfully connected to source (SQL Server) and destination (SQLite).");
+
+                // --- STEP 1: READ SCHEMA (Tables and Views) ---
+                Console.WriteLine("\n[Phase 1/2] Reading schema from SQL Server...");
+                var sourceTables = await schemaReader.GetTablesAsync(sqlConnection);
+                var sourceViews = await schemaReader.GetViewsAsync(sqlConnection); // Read the views
+                Console.WriteLine($"Found {sourceTables.Count} tables and {sourceViews.Count} views to translate.");
+
+                // --- STEP 2: WRITE SCHEMA (Tables and Views) ---
+                Console.WriteLine("[Phase 1/2] Writing translated schema to SQLite...");
+                await schemaWriter.WriteSchemaAsync(sqliteConnection, sourceTables, typeService, "SqlServer");
+                await schemaWriter.WriteViewsAsync(sqliteConnection, sourceViews); // Write the views
+                Console.WriteLine("[Phase 1/2] Schema creation complete.");
+
+                // --- STEP 3: MIGRATE DATA ---
+                Console.WriteLine("\n[Phase 2/2] Migrating data from source to destination...");
+                // Note: The data migrator only works on tables, so we pass sourceTables.
+                await dataMigrator.MigrateDataAsync(sqlConnection, sqliteConnection, sourceTables,
+                    (tableName, rows) => {
+                        Console.Write($"\r  -> Migrating {tableName}: {rows} rows transferred...");
+                    });
+                Console.WriteLine("\n[Phase 2/2] Data migration complete.");
+
+                Console.WriteLine("\n---------------------------------------");
+                Console.WriteLine("✅ Migration completed successfully!");
+                Console.WriteLine($"A new database file has been created at: {Path.GetFullPath(outputSqliteFile)}");
             }
-
-            await using var sqlConnection = new SqlConnection(sqlServerConnectionString);
-            await using var sqliteConnection = new SqliteConnection($"Data Source={outputSqliteFile}");
-            await sqlConnection.OpenAsync();
-            await sqliteConnection.OpenAsync();
-            Console.WriteLine("Successfully connected to source (SQL Server) and destination (SQLite).");
-
-            // --- STEP 1: READ SCHEMA ---
-            Console.WriteLine("\n[Phase 1/2] Reading schema from SQL Server...");
-            var sourceTables = await schemaReader.GetTablesAsync(sqlConnection);
-            Console.WriteLine($"Found {sourceTables.Count} tables to translate.");
-
-            // --- STEP 2: WRITE SCHEMA ---
-            Console.WriteLine("[Phase 1/2] Writing translated schema to SQLite...");
-            await schemaWriter.WriteSchemaAsync(sqliteConnection, sourceTables, typeService, "SqlServer");
-            Console.WriteLine("[Phase 1/2] Schema creation complete.");
-
-            // --- STEP 3: MIGRATE DATA ---
-            Console.WriteLine("\n[Phase 2/2] Migrating data from source to destination...");
-            await dataMigrator.MigrateDataAsync(sqlConnection, sqliteConnection, sourceTables,
-                (tableName, rows) => {
-                    // This is our progress reporting action
-                    Console.Write($"\r  -> Migrating {tableName}: {rows} rows transferred...");
-                });
-            Console.WriteLine("\n[Phase 2/2] Data migration complete.");
-
-            Console.WriteLine("\n---------------------------------------");
-            Console.WriteLine("✅ Migration completed successfully!");
-            Console.WriteLine($"A new database file has been created at: {Path.GetFullPath(outputSqliteFile)}");
+            catch (Exception ex)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine("\n---------------------------------------");
+                Console.WriteLine("❌ An error occurred during migration:");
+                // Use ex.ToString() to get the full exception details, including inner exceptions
+                Console.WriteLine(ex.ToString());
+                Console.ResetColor();
+            }
+            finally
+            {
+                Console.WriteLine("\nPress any key to exit...");
+                Console.ReadKey();
+            }
         }
-        catch (Exception ex)
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine("\n---------------------------------------");
-            Console.WriteLine("❌ An error occurred during migration:");
-            Console.WriteLine(ex.Message);
-            Console.WriteLine(ex.StackTrace);
-            Console.ResetColor();
-        }
-    }
 
-    static List<IDatabaseDialect> GetDialects()
-    {
-        return new List<IDatabaseDialect>
+        static List<IDatabaseDialect> GetDialects()
         {
-            new SqlServerDialect(),
-            new PostgreSqlDialect(),
-            new MySqlDialect(),
-            new SQLiteDialect()
-        };
+            return new List<IDatabaseDialect>
+            {
+                new SqlServerDialect(),
+                new PostgreSqlDialect(),
+                new MySqlDialect(),
+                new SQLiteDialect()
+            };
+        }
     }
 }


### PR DESCRIPTION
This pull request completes the core feature set for the SQL Server to SQLite migration pathway in the DbRosetta tool. It introduces robust support for a wide range of schema objects beyond basic tables, including complex constraints, triggers, and views.

The implementation follows the established reader/writer architecture and includes intelligent translation logic to handle common incompatibilities between the T-SQL (SQL Server) and SQLite dialects.

## Key Features and Enhancements Implemented

- [x] **CHECK & DEFAULT Constraints** (`6c94eeb9`)
    - Added a `CheckConstraints` property to the `TableSchema` model.
    - The `SqlServerSchemaReader` now queries `INFORMATION_SCHEMA` to retrieve `CHECK` and `DEFAULT` constraint definitions.
    - The `SQLiteWriter` has been enhanced with a sophisticated translation engine (`TranslateSqlServerExpressionToSQLite`) that handles:
        - Function mapping: `GETDATE()`/`SYSDATETIME()` → `CURRENT_TIMESTAMP`
        - `DATEADD()` translation: `dateadd(year, -18, ...)` → `date(..., '-18 years')`
        - `NEWID()` translation: `newid()` → `(lower(hex(randomblob(16))))`
        - Operator mapping for case-sensitivity: `LIKE '[A-Z]'` → `GLOB '[A-Z]'`

- [x] **UNIQUE Constraints & IDENTITY Columns** (`bcb18ce5`)
    - Added support for migrating `UNIQUE` constraints from SQL Server to SQLite.
    - The reader now correctly detects `IDENTITY` columns in SQL Server.
    - The writer generates the proper `INTEGER PRIMARY KEY AUTOINCREMENT` syntax for SQLite, preserving auto-incrementing behavior.

- [x] **Triggers** (`bcb18ce5`)
    - The `SqlServerSchemaReader` now discovers triggers, their target tables, events (`INSERT`, `UPDATE`, `DELETE`), and types (`AFTER`, `INSTEAD OF`).
    - The `SQLiteWriter` creates a valid placeholder trigger in SQLite. To ensure the migration never fails due to syntax errors, the original T-SQL body is embedded as safe line comments (`--`).
    - Gracefully handles dialect incompatibilities, converting an invalid `INSTEAD OF` trigger on a table into a safe, commented-out `AFTER` trigger with a clear warning.

- [x] **Database Views** (`e687a6fa`)
    - The schema reader and writer interfaces have been extended with dedicated methods (`GetViewsAsync`, `WriteViewsAsync`) to support views.
    - The `SqlServerSchemaReader` now fetches all view definitions from `INFORMATION_SCHEMA.VIEWS`.
    - The `SQLiteWriter` creates a valid placeholder `VIEW` in SQLite (`SELECT 'placeholder' AS MigrationMessage;`) and embeds the original T-SQL definition as a series of line comments for manual translation.

- [x] **Data Migration Hardening** (`a7973c4a`)
    - The `DataMigrator` service has been enhanced to trim all incoming string data (`stringValue.Trim()`). This crucial fix handles the invisible whitespace padding from fixed-length SQL Server data types (like `nchar` and `char`), preventing erroneous `CHECK` constraint failures during data insertion.

## How to Test

1.  Ensure you have an instance of SQL Server with the `AdventureWorks2014` database restored.
2.  Update the connection string in `DbRosetta.ExampleConsoleApp/Program.cs` to point to your instance.
3.  Run the `DbRosetta.ExampleConsoleApp` project.
4.  The migration should complete successfully from end to end without any errors.
5.  Open the generated `MyTranslatedDb.sqlite` file with a tool like DB Browser for SQLite.
6.  **Verify Constraints:**
    -   Inspect the schema for the `Employee` table. Verify that the `CHECK` constraints for `BirthDate` and `HireDate` are using the SQLite `date()` function.
        ```sql
        CHECK("BirthDate" >= '1930-01-01' AND "BirthDate" <= date(CURRENT_TIMESTAMP, '-18 years'))
        ```
    -   Inspect the schema for `ProductInventory`. Verify the `CHECK` constraint for the `Shelf` column is using the `GLOB` operator.
        ```sql
        CHECK(UPPER("Shelf") GLOB '[A-Z]' OR "Shelf" = 'N/A')
        ```
7.  **Verify Identity:**
    -   Inspect the schema for `ProductCategory`. The `ProductCategoryID` column should be defined as:
        ```sql
        "ProductCategoryID" INTEGER PRIMARY KEY AUTOINCREMENT
        ```
8.  **Verify Triggers & Views:**
    -   Confirm that triggers like `dVendor` and views like `vGetAllCategories` exist in the SQLite database.
    -   Inspect their definitions to confirm they are valid placeholders with the original T-SQL commented out for developer reference.